### PR TITLE
Added dotenv to regular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,8 +1643,7 @@
     "dotenv": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
-      "dev": true
+      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/SlimeDevs/task-app#readme",
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "dotenv": "^8.0.0",
     "ejs": "^2.6.2",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
@@ -45,7 +46,6 @@
     "@types/mongoose": "^5.5.6",
     "@types/supertest": "^2.0.7",
     "@types/validator": "^10.11.1",
-    "dotenv": "^8.0.0",
     "jest": "^24.8.0",
     "nodemon": "^1.19.1",
     "supertest": "^4.0.2",


### PR DESCRIPTION
Changing dotenv to a regular dependency so heroku can recognize the package and not error on a non-existent dependency. 