### PR TITLE
Rename Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ npm install
 | DELETE | /tasks/:id       | Delete a user task (Delete) | Yes           |
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 
 ## License
+
 [AGPL-3.0](https://choosealicense.com/licenses/agpl-3.0/)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Task Manager [![Build Status](https://travis-ci.com/brady-miller/task-manager.svg?branch=master)](https://travis-ci.com/brady-miller/task-manager) [![dependencies Status](https://david-dm.org/brady-miller/task-manager/status.svg)](https://david-dm.org/brady-miller/task-manager)
+# Todo API [![Build Status](https://travis-ci.com/brady-miller/todo-api.svg?branch=master)](https://travis-ci.com/brady-miller/todo-api) [![dependencies Status](https://david-dm.org/brady-miller/todo-api/status.svg)](https://david-dm.org/brady-miller/todo-api)
 
-Task Manager is a simple task managing web app using a REST API.
+Todo API is a simple task managing web app using a REST API.
 
 ## Installation
 
 Clone the github repo using git clone
 
 ```bash
-git clone https://github.com/SlimeDevs/task-app.git
+git clone https://github.com/brady-miller/todo-api.git
 ```
 
 Then run npm install to install all needed dependencies

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Please make sure to update tests as appropriate.
 
 ## License
 
-[AGPL-3.0](https://choosealicense.com/licenses/agpl-3.0/)
+[Apache-2.0](https://choosealicense.com/licenses/apache-2.0/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "task-manager",
+  "name": "todo-api",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "task-manager",
+  "name": "todo-api",
   "version": "0.0.0",
-  "description": "The source code for my task app",
-  "main": "index.js",
+  "description": "A todo app REST API with typescript and express",
+  "main": "/dist/index.js",
   "scripts": {
     "start": "cross-env NODE_ENV=production npm run build && node dist/index.js",
     "dev": "cross-env NODE_ENV=development nodemon",
@@ -11,19 +11,20 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/brady-miller/task-manager.git"
+    "url": "git+https://github.com/brady-miller/todo-api.git"
   },
   "keywords": [
-    "tasks",
-    "task-app",
-    "task-manager"
+    "todos",
+    "todo-api",
+    "todo-app",
+    "todo-manager"
   ],
   "author": "Brady Miller",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/brady-miller/task-app/issues"
+    "url": "https://github.com/brady-miller/todo-api/issues"
   },
-  "homepage": "https://github.com/brady-miller/task-app#readme",
+  "homepage": "https://github.com/brady-miller/todo-api#readme",
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "dotenv": "^8.0.0",


### PR DESCRIPTION
To properly represent the new purpose of this standalone todo api, I have renamed most of the project to "Todo-API". This may have some breaking changes when merged, but should be fixed quickly.